### PR TITLE
#13 - 데이터베이스 접근 로직 구현

### DIFF
--- a/src/main/java/com/board/boardpractice/domain/Article.java
+++ b/src/main/java/com/board/boardpractice/domain/Article.java
@@ -4,13 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -23,18 +17,23 @@ import java.util.Set;
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy"),
 })
-@EntityListeners(AuditingEntityListener.class)
+//@EntityListeners(AuditingEntityListener.class) // -> MappedSuperclass 클래스에 배치가 가능
 @Entity
-public class Article {
+public class Article extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // mysql은 IDENTITY 방식으로 auto increase 됨
     private Long id;
 
-    @Setter @Column(nullable = false) private String title;
-    @Setter @Column(nullable = false, length = 10000) private String content;
+    @Setter
+    @Column(nullable = false)
+    private String title;
+    @Setter
+    @Column(nullable = false, length = 10000)
+    private String content;
 
-    @Setter private String hashtag;
+    @Setter
+    private String hashtag;
 
     // 양방향 설정
     @ToString.Exclude // 양방향 바인딩으로 인한 순환 참조(무한루프) 제외 처리
@@ -43,12 +42,18 @@ public class Article {
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
     // metadata EnableJpaAuditing 설정
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt;
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy;
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt;
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy;
+//    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt;
+//    @CreatedBy @Column(nullable = false, length = 100) private String createdBy;
+//    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt;
+//    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy;
 
-    protected Article() {} // 외부에서 생성자 생성 못하게 설정
+    // 중복되는 column을 추출하는 방법은 2가지가 있다.
+//    @MappedSuperclass : AuditingFields를 extends해서 사용
+//    @Embedded : 공통 컬럼들을 모은 클래스를 하나의 필드로 설정하는 방법
+//    당연하지만 주의사항으로 컬럼을 공통으로 사용하면 장단점이 있을 것이다.
+
+    protected Article() {
+    } // 외부에서 생성자 생성 못하게 설정
 
     private Article(String title, String content, String hashtag) {
         this.title = title;

--- a/src/main/java/com/board/boardpractice/domain/AuditingFields.java
+++ b/src/main/java/com/board/boardpractice/domain/AuditingFields.java
@@ -1,0 +1,37 @@
+package com.board.boardpractice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false) private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(nullable = false, length = 100, updatable = false) private String createdBy;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false) private LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100) private String modifiedBy;
+
+}


### PR DESCRIPTION
생성자, 생성일시, 수정자, 수정일시는 반복적으로
엔티티 클래스에 들어가는 요소이고, 도메인과 직접 연관이 없는 요소임으로 추출이 가능하다.

`@MappedSuperclass` 이용하여 상속 방식으로 추출함. ArticleComment는 하지 않음.

그외 `@DateTimeFormat` 요소 추가 및 jpa 옵션 개선.

This closes #13 
