### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/board/boardpractice/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/board/boardpractice/dto/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.board.boardpractice.dto.response;
 
 import com.board.boardpractice.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/com/board/boardpractice/dto/response/ArticleResponse.java
+++ b/src/main/java/com/board/boardpractice/dto/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.board.boardpractice.dto.response;
 
 import com.board.boardpractice.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
     /*
     * 컨트롤러에서만 사용할 DTO
     * 레이어별로 DTO를 분리시킴으로써, 각 레이어의 독립성 보장과 유연한 코드로의 확장 가능.

--- a/src/main/java/com/board/boardpractice/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/board/boardpractice/dto/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.board.boardpractice.dto.response;
 
 import com.board.boardpractice.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데, 자동으로 `implements Serializable` 이 들어가버림. 우리 프로젝트는 직렬화로 Jackson을 사용하므로 필요하지 않고, 의도하여 넣은 코드도 아니기에 삭제